### PR TITLE
Fix redirection in demo

### DIFF
--- a/website/static/js/intro-manager.js
+++ b/website/static/js/intro-manager.js
@@ -424,6 +424,7 @@ function runPostGameIntro(redirectUrl = null) {
   });
 
   intro.onbeforechange(function (target) {
+    if (!target) return;
     if (target.id === 'postNewGame') {
       annoncesDropdown.show();
     }
@@ -433,6 +434,7 @@ function runPostGameIntro(redirectUrl = null) {
   });
 
   intro.onafterchange(function (target) {
+    if (!target) return;
     if (target.id !== 'postNewGame') {
       annoncesDropdown.hide();
     }


### PR DESCRIPTION
Redirection in demo between the publish and manage sections was broken.
Add behaviour for empty targets in `onbeforechange` and `onafterchange` to avoid the `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'id')` error.