### PR TITLE
Fix overflow on huge games

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -157,6 +157,7 @@ figure {
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+  overflow-wrap: anywhere;
 }
 
 .top-info h1 {


### PR DESCRIPTION
Long game description created an overflow making the info-top block text covering the actions button on some screens