### PR TITLE
Fix edit session embed signature

### DIFF
--- a/website/views/games/embeds.py
+++ b/website/views/games/embeds.py
@@ -117,7 +117,7 @@ def build_add_session_embed(game, start, end, *_):
     return embed, game.channel
 
 
-def build_edit_session_embed(game, start, end, _, old_start, old_end):
+def build_edit_session_embed(game, start, end, _, old_start, old_end, *__):
     embed = {
         "title": "Session modifiée",
         "color": 0xFFCF48,  # yellow


### PR DESCRIPTION
Add missing parameters to prevent the error when trying to edit a session.