### PR TITLE
Fix scheduler for marking users as inactive

### DIFF
--- a/tests/repositories/test_user_repository.py
+++ b/tests/repositories/test_user_repository.py
@@ -61,3 +61,32 @@ class TestUserRepository:
         inactive_users = repo.get_inactive_users()
         inactive_ids = [u.id for u in inactive_users]
         assert active_user.id not in inactive_ids
+
+    def test_get_active_user_ids(self, db_session):
+        repo = UserRepository()
+        active_user = UserFactory(db_session)
+        inactive_user = UserFactory(db_session, not_player_as_of=datetime(2025, 1, 1))
+        ids = repo.get_active_user_ids()
+        assert active_user.id in ids
+        assert inactive_user.id not in ids
+
+    def test_get_inactive_user_ids(self, db_session):
+        repo = UserRepository()
+        active_user = UserFactory(db_session)
+        inactive_user = UserFactory(db_session, not_player_as_of=datetime(2025, 1, 1))
+        ids = repo.get_inactive_user_ids()
+        assert inactive_user.id in ids
+        assert active_user.id not in ids
+
+    def test_get_by_ids(self, db_session):
+        repo = UserRepository()
+        user1 = UserFactory(db_session)
+        user2 = UserFactory(db_session)
+        results = repo.get_by_ids([user1.id, user2.id])
+        result_ids = [u.id for u in results]
+        assert user1.id in result_ids
+        assert user2.id in result_ids
+
+    def test_get_by_ids_empty(self, db_session):
+        repo = UserRepository()
+        assert repo.get_by_ids([]) == []

--- a/tests/services/test_user_service.py
+++ b/tests/services/test_user_service.py
@@ -58,6 +58,31 @@ class TestUserService:
         inactive_ids = [u.id for u in inactive_users]
         assert inactive_user.id in inactive_ids
 
+    def test_get_active_user_ids(self, db_session):
+        active_user = UserFactory(db_session)
+        inactive_user = UserFactory(db_session, not_player_as_of=datetime(2025, 1, 1))
+        service = UserService()
+        ids = service.get_active_user_ids()
+        assert active_user.id in ids
+        assert inactive_user.id not in ids
+
+    def test_get_inactive_user_ids(self, db_session):
+        active_user = UserFactory(db_session)
+        inactive_user = UserFactory(db_session, not_player_as_of=datetime(2025, 1, 1))
+        service = UserService()
+        ids = service.get_inactive_user_ids()
+        assert inactive_user.id in ids
+        assert active_user.id not in ids
+
+    def test_get_by_ids(self, db_session):
+        user1 = UserFactory(db_session)
+        user2 = UserFactory(db_session)
+        service = UserService()
+        results = service.get_by_ids([user1.id, user2.id])
+        result_ids = [u.id for u in results]
+        assert user1.id in result_ids
+        assert user2.id in result_ids
+
     def test_mark_inactive(self, db_session):
         user = UserFactory(db_session)
         service = UserService()

--- a/website/repositories/user.py
+++ b/website/repositories/user.py
@@ -17,6 +17,43 @@ class UserRepository(BaseRepository[User]):
         """
         return self.session.query(User).filter(User.not_player_as_of.is_(None)).all()
 
+    def get_active_user_ids(self) -> list[str]:
+        """Retrieve IDs of all users not marked as inactive.
+
+        Uses a scalar query to avoid loading full ORM objects
+        (and triggering init_on_load).
+
+        Returns:
+            List of user ID strings where not_player_as_of is NULL.
+        """
+        rows = self.session.query(User.id).filter(User.not_player_as_of.is_(None)).all()
+        return [row[0] for row in rows]
+
+    def get_inactive_user_ids(self) -> list[str]:
+        """Retrieve IDs of all users marked as inactive.
+
+        Uses a scalar query to avoid loading full ORM objects
+        (and triggering init_on_load).
+
+        Returns:
+            List of user ID strings where not_player_as_of is set.
+        """
+        rows = self.session.query(User.id).filter(User.not_player_as_of.isnot(None)).all()
+        return [row[0] for row in rows]
+
+    def get_by_ids(self, ids: list[str]) -> list[User]:
+        """Retrieve users by a list of IDs.
+
+        Args:
+            ids: List of user ID strings.
+
+        Returns:
+            List of User instances matching the given IDs.
+        """
+        if not ids:
+            return []
+        return self.session.query(User).filter(User.id.in_(ids)).all()
+
     def get_inactive_users(self) -> list[User]:
         """Retrieve all users marked as inactive.
 

--- a/website/services/user.py
+++ b/website/services/user.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from website.exceptions import NotFoundError
 from website.extensions import db
 from website.models import User
+from website.models.user import get_user_profile as _get_user_profile
 from website.repositories.user import UserRepository
 
 
@@ -76,6 +77,16 @@ class UserService:
         """
         return self.repo.get_active_users()
 
+    def get_active_user_ids(self) -> list[str]:
+        """Get IDs of all users not marked as inactive.
+
+        Lightweight query that avoids loading full ORM objects.
+
+        Returns:
+            List of active user ID strings.
+        """
+        return self.repo.get_active_user_ids()
+
     def get_inactive_users(self) -> list[User]:
         """Get all users marked as inactive.
 
@@ -83,6 +94,40 @@ class UserService:
             List of inactive User instances.
         """
         return self.repo.get_inactive_users()
+
+    def get_inactive_user_ids(self) -> list[str]:
+        """Get IDs of all users marked as inactive.
+
+        Lightweight query that avoids loading full ORM objects.
+
+        Returns:
+            List of inactive user ID strings.
+        """
+        return self.repo.get_inactive_user_ids()
+
+    def get_by_ids(self, ids: list[str]) -> list[User]:
+        """Get users by a list of IDs.
+
+        Args:
+            ids: List of user ID strings.
+
+        Returns:
+            List of User instances matching the given IDs.
+        """
+        return self.repo.get_by_ids(ids)
+
+    @staticmethod
+    def get_user_profile(user_id: str, force_refresh: bool = False) -> dict:
+        """Fetch a user's Discord profile.
+
+        Args:
+            user_id: Discord user ID.
+            force_refresh: If True, bypass cache and fetch from Discord.
+
+        Returns:
+            Dict with 'name', 'avatar', and optionally 'not_found' keys.
+        """
+        return _get_user_profile(user_id, force_refresh=force_refresh)
 
     def mark_inactive(self, user_id: str) -> User:
         """Mark a user as inactive (left the Discord server).


### PR DESCRIPTION
The scheduled profile refresh loaded all active User ORM objects,
triggering init_on_load (and a Discord API call) for every user—not
just the batch being refreshed. Departed users caused repeated 404s,
rate limiting, and jobs exceeding the 5-minute interval before the
not_player_as_of flag could be committed.

Query only user IDs first (no ORM load), sample the batch, then load
just those users. Same fix applied to check_inactive_users.
