### PR TITLE
fix(sonar): sanitize logged trophy names and associate form inputs with labels

### DIFF
--- a/website/services/trophy.py
+++ b/website/services/trophy.py
@@ -8,6 +8,7 @@ from website.models.trophy import Trophy, UserTrophy
 from website.models.user import User
 from website.repositories.base import Pagination
 from website.repositories.trophy import TrophyRepository
+from website.utils.logger import sanitize_log_value
 
 logger = logging.getLogger(__name__)
 
@@ -277,13 +278,22 @@ class TrophyService:
             # Unique trophies: only award once
             if user_trophy is None:
                 user_trophy = self.repo.award_trophy(user_id, trophy_id, amount=1)
-                logger.info(f"User {user_id} got a trophy: {trophy.name}")
+                logger.info("User %s got a trophy: %s", user_id, sanitize_log_value(trophy.name))
             else:
-                logger.debug(f"User {user_id} already has unique trophy {trophy.name}, skipping")
+                logger.debug(
+                    "User %s already has unique trophy %s, skipping",
+                    user_id,
+                    sanitize_log_value(trophy.name),
+                )
         else:
             # Non-unique trophies: increment quantity
             user_trophy = self.repo.award_trophy(user_id, trophy_id, amount)
-            logger.info(f"User {user_id} got a trophy: {trophy.name} (x{amount})")
+            logger.info(
+                "User %s got a trophy: %s (x%s)",
+                user_id,
+                sanitize_log_value(trophy.name),
+                amount,
+            )
 
         db.session.commit()
         return user_trophy

--- a/website/templates/admin/channels/form.html
+++ b/website/templates/admin/channels/form.html
@@ -14,7 +14,8 @@
     <div class="flex flex-col gap-1">
       <label for="id" class="{{ lbl }}">Discord ID</label>
       {% if channel %}
-      <input type="text" class="input input-bordered w-full font-mono" value="{{ channel.id }}" disabled>
+      <input type="text" id="id" class="input input-bordered w-full font-mono" value="{{ channel.id }}"
+             disabled>
       {% else %}
       <input type="text" id="id" name="id" class="input input-bordered w-full font-mono" required
              autocomplete="off" placeholder="123456789012345678">

--- a/website/templates/admin/discord/compose.html
+++ b/website/templates/admin/discord/compose.html
@@ -26,7 +26,7 @@
     <div class="flex flex-col gap-1">
       <label for="channel" class="{{ lbl }}">Salon</label>
       {% if is_edit %}
-      <input type="text" class="input input-bordered w-full"
+      <input type="text" id="channel" class="input input-bordered w-full"
              value="{{ message.channel_label or message.channel_id }}" disabled>
       <span class="text-xs text-base-content/40">Le salon d'un message envoyé ne peut pas être modifié.</span>
       {% else %}

--- a/website/templates/admin/user_trophies/list.html
+++ b/website/templates/admin/user_trophies/list.html
@@ -62,8 +62,9 @@
           <form method="post" id="ut-{{ ut.trophy_id }}"
                 action="{{ url_for('admin.edit_user_trophy', user_id=user.id, trophy_id=ut.trophy_id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <input type="number" name="quantity" value="{{ ut.quantity }}" min="1"
-                   class="input input-bordered input-sm w-24">
+            <label for="quantity-{{ ut.trophy_id }}" class="sr-only">Quantité de {{ ut.trophy.name }}</label>
+            <input type="number" id="quantity-{{ ut.trophy_id }}" name="quantity" value="{{ ut.quantity }}"
+                   min="1" class="input input-bordered input-sm w-24">
           </form>
           {% endif %}
         </td>

--- a/website/templates/admin/users/edit.html
+++ b/website/templates/admin/users/edit.html
@@ -10,8 +10,9 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
     <div class="flex flex-col gap-1">
-      <label class="{{ lbl }}">Discord ID</label>
-      <input type="text" class="input input-bordered w-full font-mono" value="{{ user.id }}" disabled>
+      <label for="discord_id" class="{{ lbl }}">Discord ID</label>
+      <input type="text" id="discord_id" class="input input-bordered w-full font-mono"
+             value="{{ user.id }}" disabled>
     </div>
 
     <div class="flex flex-col gap-1">

--- a/website/utils/logger.py
+++ b/website/utils/logger.py
@@ -13,6 +13,21 @@ class RequestLoggerAdapter(logging.LoggerAdapter):
         return f"[trace_id={trace_id}] {msg}", kwargs
 
 
+def sanitize_log_value(value: object) -> str:
+    """Sanitize a user-controlled value for safe logging.
+
+    Strips characters that could forge or break log lines (CR, LF and other
+    control characters), mitigating log injection from user-supplied data.
+
+    Args:
+        value: Value to sanitize (coerced to ``str``).
+
+    Returns:
+        A single-line string safe to embed in a log message.
+    """
+    return "".join(c for c in str(value) if c.isprintable())
+
+
 def configure_logging(level=logging.INFO):
     """Configure the root logger with a stream handler.
 


### PR DESCRIPTION

- Add sanitize_log_value() and use it for user-controlled trophy.name in logs
- Add id/label associations to admin channel, discord, user and trophy forms
