### PR TITLE
feat(games): allow upgrading a published one-shot to a campaign

### DIFF
--- a/tests/services/test_discord_service.py
+++ b/tests/services/test_discord_service.py
@@ -73,6 +73,15 @@ class TestDiscordService:
         mock_bot.delete_role.assert_called_once_with("role123")
         assert result == {}
 
+    def test_update_role_color(self, discord_service, mock_bot):
+        """Test updating a Discord role's color."""
+        mock_bot.update_role_color.return_value = {"id": "role123", "color": 0x0D6EFD}
+
+        result = discord_service.update_role_color("role123", 0x0D6EFD)
+
+        mock_bot.update_role_color.assert_called_once_with("role123", 0x0D6EFD)
+        assert result["color"] == 0x0D6EFD
+
     def test_count_roles(self, discord_service, mock_bot):
         """count_roles returns the number of guild roles."""
         mock_bot.list_roles.return_value = [{"id": "1"}, {"id": "2"}, {"id": "3"}]

--- a/tests/services/test_game_service.py
+++ b/tests/services/test_game_service.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from config.constants import PLAYER_ROLE_PERMISSION
-from tests.factories import GameFactory, UserFactory
+from tests.factories import GameFactory, SpecialEventFactory, UserFactory
 from website.exceptions import (
     DiscordAPIError,
     DuplicateRegistrationError,
@@ -15,6 +15,7 @@ from website.exceptions import (
     NotFoundError,
     ValidationError,
 )
+from website.models import Game
 from website.services.game import GameService
 
 
@@ -342,6 +343,230 @@ class TestGameService:
 
         assert game.slug == old_slug
         assert game.name == sample_game.name
+
+    @patch("website.utils.form_parsers.get_classification")
+    @patch("website.utils.form_parsers.get_ambience")
+    @patch("website.utils.form_parsers.parse_restriction_tags")
+    def test_update_published_oneshot_can_upgrade_to_campaign(
+        self,
+        mock_tags,
+        mock_ambience,
+        mock_class,
+        db_session,
+        sample_game,
+        default_system,
+        game_service,
+        mock_discord,
+        oneshot_channel,
+        campaign_channel,
+    ):
+        mock_class.return_value = {}
+        mock_ambience.return_value = []
+        mock_tags.return_value = None
+        sample_game.status = "open"
+        sample_game.role = "role_123"
+        sample_game.channel = oneshot_channel.id
+        db_session.commit()
+
+        data = {
+            "name": sample_game.name,
+            "type": "campaign",
+            "system": default_system.id,
+            "description": "desc",
+            "restriction": "all",
+            "party_size": 4,
+            "xp": "all",
+            "date": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "length": "3h",
+            "session_length": 3.0,
+            "characters": "self",
+        }
+
+        game = game_service.update(sample_game.slug, data)
+
+        assert game.type == "campaign"
+        mock_discord.update_channel_parent.assert_called_once_with(
+            oneshot_channel.id, campaign_channel.id
+        )
+        mock_discord.update_role_color.assert_called_once_with("role_123", Game.COLORS["campaign"])
+
+    @patch("website.utils.form_parsers.get_classification")
+    @patch("website.utils.form_parsers.get_ambience")
+    @patch("website.utils.form_parsers.parse_restriction_tags")
+    def test_update_published_campaign_can_downgrade_to_oneshot(
+        self,
+        mock_tags,
+        mock_ambience,
+        mock_class,
+        db_session,
+        sample_game,
+        default_system,
+        game_service,
+        mock_discord,
+        oneshot_channel,
+        campaign_channel,
+    ):
+        mock_class.return_value = {}
+        mock_ambience.return_value = []
+        mock_tags.return_value = None
+        sample_game.type = "campaign"
+        sample_game.status = "open"
+        sample_game.role = "role_456"
+        sample_game.channel = campaign_channel.id
+        db_session.commit()
+
+        data = {
+            "name": sample_game.name,
+            "type": "oneshot",
+            "system": default_system.id,
+            "description": "desc",
+            "restriction": "all",
+            "party_size": 4,
+            "xp": "all",
+            "date": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "length": "3h",
+            "session_length": 3.0,
+            "characters": "self",
+        }
+
+        game = game_service.update(sample_game.slug, data)
+
+        assert game.type == "oneshot"
+        mock_discord.update_channel_parent.assert_called_once_with(
+            campaign_channel.id, oneshot_channel.id
+        )
+        mock_discord.update_role_color.assert_called_once_with("role_456", Game.COLORS["oneshot"])
+
+    @patch("website.utils.form_parsers.get_classification")
+    @patch("website.utils.form_parsers.get_ambience")
+    @patch("website.utils.form_parsers.parse_restriction_tags")
+    def test_update_published_game_type_unchanged_skips_move_and_recolor(
+        self,
+        mock_tags,
+        mock_ambience,
+        mock_class,
+        db_session,
+        sample_game,
+        default_system,
+        game_service,
+        mock_discord,
+        oneshot_channel,
+    ):
+        mock_class.return_value = {}
+        mock_ambience.return_value = []
+        mock_tags.return_value = None
+        sample_game.status = "open"
+        sample_game.role = "role_123"
+        sample_game.channel = oneshot_channel.id
+        db_session.commit()
+
+        data = {
+            "name": sample_game.name,
+            "type": "oneshot",
+            "system": default_system.id,
+            "description": "desc",
+            "restriction": "all",
+            "party_size": 4,
+            "xp": "all",
+            "date": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "length": "3h",
+            "session_length": 3.0,
+            "characters": "self",
+        }
+
+        game = game_service.update(sample_game.slug, data)
+
+        assert game.type == "oneshot"
+        mock_discord.update_channel_parent.assert_not_called()
+        mock_discord.update_role_color.assert_not_called()
+
+    @patch("website.utils.form_parsers.get_classification")
+    @patch("website.utils.form_parsers.get_ambience")
+    @patch("website.utils.form_parsers.parse_restriction_tags")
+    def test_update_published_special_event_game_type_stays_locked(
+        self,
+        mock_tags,
+        mock_ambience,
+        mock_class,
+        db_session,
+        sample_game,
+        default_system,
+        game_service,
+        mock_discord,
+        admin_user,
+    ):
+        mock_class.return_value = {}
+        mock_ambience.return_value = []
+        mock_tags.return_value = None
+        event = SpecialEventFactory(db_session)
+        sample_game.status = "open"
+        sample_game.special_event_id = event.id
+        db_session.commit()
+
+        data = {
+            "name": sample_game.name,
+            "type": "campaign",
+            "system": default_system.id,
+            "description": "desc",
+            "restriction": "all",
+            "party_size": 4,
+            "xp": "all",
+            "date": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "length": "3h",
+            "session_length": 3.0,
+            "characters": "self",
+        }
+
+        game = game_service.update(sample_game.slug, data)
+
+        assert game.type == "oneshot"
+        assert game.special_event_id == event.id
+        mock_discord.update_channel_parent.assert_not_called()
+        mock_discord.update_role_color.assert_not_called()
+
+    @patch("website.utils.form_parsers.get_classification")
+    @patch("website.utils.form_parsers.get_ambience")
+    @patch("website.utils.form_parsers.parse_restriction_tags")
+    def test_update_published_type_change_without_role_skips_recolor(
+        self,
+        mock_tags,
+        mock_ambience,
+        mock_class,
+        db_session,
+        sample_game,
+        default_system,
+        game_service,
+        mock_discord,
+        oneshot_channel,
+        campaign_channel,
+    ):
+        mock_class.return_value = {}
+        mock_ambience.return_value = []
+        mock_tags.return_value = None
+        sample_game.status = "open"
+        sample_game.role = None
+        sample_game.channel = oneshot_channel.id
+        db_session.commit()
+
+        data = {
+            "name": sample_game.name,
+            "type": "campaign",
+            "system": default_system.id,
+            "description": "desc",
+            "restriction": "all",
+            "party_size": 4,
+            "xp": "all",
+            "date": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "length": "3h",
+            "session_length": 3.0,
+            "characters": "self",
+        }
+
+        game = game_service.update(sample_game.slug, data)
+
+        assert game.type == "campaign"
+        mock_discord.update_channel_parent.assert_called_once()
+        mock_discord.update_role_color.assert_not_called()
 
     def test_publish_game(
         self, db_session, sample_game, mock_discord, game_service, oneshot_channel

--- a/tests/utils/test_discord_client.py
+++ b/tests/utils/test_discord_client.py
@@ -68,6 +68,15 @@ class TestRolesAndMessages:
 
         assert req.call_args.kwargs["endpoint"] == "/guilds/guild_1/roles"
 
+    def test_update_role_color(self, client):
+        """update_role_color PATCHes the role with the new color."""
+        with patch.object(Discord, "_request", return_value={"id": "role_9"}) as req:
+            client.update_role_color("role_9", 0x0D6EFD)
+
+        assert req.call_args.kwargs["endpoint"] == "/guilds/guild_1/roles/role_9"
+        assert req.call_args.kwargs["method"] == "PATCH"
+        assert req.call_args.kwargs["json"] == {"color": 0x0D6EFD}
+
     def test_send_message_forwards_allowed_mentions(self, client):
         """allowed_mentions is included in the message payload when provided."""
         allowed = {"parse": ["users", "roles"]}

--- a/website/client/discord.py
+++ b/website/client/discord.py
@@ -348,6 +348,20 @@ class Discord:
         """
         return self._request(endpoint=f"/channels/{channel_id}", method="DELETE")
 
+    def update_channel_parent(self, channel_id: str, parent_id: str) -> dict:
+        """Move a channel under a different parent category.
+
+        Args:
+            channel_id: Channel to move.
+            parent_id: ID of the destination category.
+
+        Returns:
+            Dict with the updated channel data.
+        """
+        return self._request(
+            endpoint=f"/channels/{channel_id}", method="PATCH", json={"parent_id": parent_id}
+        )
+
     def create_role(self, role_name: str, permissions: str, color: int) -> dict:
         """Create a new guild role.
 

--- a/website/client/discord.py
+++ b/website/client/discord.py
@@ -383,6 +383,22 @@ class Discord:
             endpoint=f"/guilds/{self.guild_id}/roles", method="POST", json=payload
         )
 
+    def update_role_color(self, role_id: str, color: int) -> dict:
+        """Update a guild role's color.
+
+        Args:
+            role_id: Role ID to update.
+            color: New role color as integer.
+
+        Returns:
+            Dict with the updated role data.
+        """
+        return self._request(
+            endpoint=f"/guilds/{self.guild_id}/roles/{role_id}",
+            method="PATCH",
+            json={"color": color},
+        )
+
     def list_roles(self) -> list:
         """Fetch all roles defined in the guild.
 

--- a/website/services/channel.py
+++ b/website/services/channel.py
@@ -235,6 +235,43 @@ class ChannelService:
             return self.create_category(discord_service, type)
         return None
 
+    def move_game_channel(self, discord_service: DiscordService, game: Game, new_type: str) -> None:
+        """Move a game's Discord channel to a category matching its new type.
+
+        Used when a game's type changes after its channel already exists (e.g. a
+        one-shot upgraded to a campaign): relocates the channel on Discord and
+        keeps tracked category sizes in sync. A no-op if the game has no channel
+        yet (nothing to move).
+
+        Args:
+            discord_service: DiscordService instance for API calls.
+            game: Game instance whose channel should be relocated.
+            new_type: Destination game type (``oneshot`` or ``campaign``).
+
+        Raises:
+            NotFoundError: If no category is registered for ``new_type``.
+        """
+        if not game.channel:
+            return
+
+        destination = self.get_category(new_type)
+
+        old_parent_id = None
+        try:
+            old_parent_id = discord_service.get_channel(game.channel).get("parent_id")
+        except Exception as e:
+            logger.warning(f"Could not read current category for channel {game.channel}: {e}")
+
+        discord_service.update_channel_parent(game.channel, destination.id)
+        logger.info(f"Channel {game.channel} moved to category {destination.id}")
+
+        if old_parent_id and old_parent_id != destination.id:
+            old_category = self.repo.get_by_id(old_parent_id)
+            if old_category:
+                self.repo.decrement_size(old_category)
+        self.repo.increment_size(destination)
+        db.session.commit()
+
     def adjust_category_size(self, discord_service: DiscordService, game: Game) -> None:
         """Decrement category size when a game channel is deleted.
 

--- a/website/services/channel.py
+++ b/website/services/channel.py
@@ -235,7 +235,9 @@ class ChannelService:
             return self.create_category(discord_service, type)
         return None
 
-    def move_game_channel(self, discord_service: DiscordService, game: Game, new_type: str) -> None:
+    def move_game_channel(
+        self, discord_service: DiscordService, game: Game, new_type: str
+    ) -> None:
         """Move a game's Discord channel to a category matching its new type.
 
         Used when a game's type changes after its channel already exists (e.g. a

--- a/website/services/discord.py
+++ b/website/services/discord.py
@@ -325,6 +325,21 @@ class DiscordService:
         """
         return self.bot.delete_channel(channel_id)
 
+    def update_channel_parent(self, channel_id: str, parent_id: str) -> dict:
+        """Move a channel under a different parent category.
+
+        Args:
+            channel_id: Discord channel ID to move.
+            parent_id: ID of the destination category.
+
+        Returns:
+            Dict with the updated channel data.
+
+        Raises:
+            DiscordAPIError: If the API request fails.
+        """
+        return self.bot.update_channel_parent(channel_id, parent_id)
+
     # -------------------------------------------------------------------------
     # Message operations
     # -------------------------------------------------------------------------

--- a/website/services/discord.py
+++ b/website/services/discord.py
@@ -141,6 +141,21 @@ class DiscordService:
         """
         return self.bot.get_role(role_id)
 
+    def update_role_color(self, role_id: str, color: int) -> dict:
+        """Update a Discord role's color.
+
+        Args:
+            role_id: Discord role ID.
+            color: New role color as integer.
+
+        Returns:
+            Updated role data.
+
+        Raises:
+            DiscordAPIError: If the API request fails.
+        """
+        return self.bot.update_role_color(role_id, color)
+
     def list_roles(self) -> list:
         """Return all roles defined in the guild.
 

--- a/website/services/game.py
+++ b/website/services/game.py
@@ -467,6 +467,7 @@ class GameService:
 
         game = self.get_by_slug(slug)
 
+        type_upgraded = False
         try:
             # Only allow type/name changes if game is draft
             if game.status == "draft":
@@ -479,6 +480,19 @@ class GameService:
                         data["name"], gm.slug_name, exclude_slug=game.slug
                     )
                 game.name = data["name"]
+            elif "type" in data:
+                # Once published, only a one-shot -> campaign upgrade is allowed (a
+                # game running longer than planned), never the reverse, and never
+                # into/out of a special event. Name/slug stay locked outside draft.
+                game_type, special_event_id = self.parse_game_type(data["type"])
+                if (
+                    game.type == "oneshot"
+                    and game_type == "campaign"
+                    and special_event_id is None
+                    and game.special_event_id is None
+                ):
+                    game.type = game_type
+                    type_upgraded = True
 
             # Update fields
             game.system_id = data["system"]
@@ -512,6 +526,13 @@ class GameService:
                     logger.info(f"Embed updated for game {game.id}")
                 except DiscordAPIError as e:
                     logger.warning(f"Failed to update Discord embed for game {game.id}: {e}")
+
+            # Relocate the Discord channel to the campaign category on upgrade
+            if type_upgraded:
+                try:
+                    self.channel_service.move_game_channel(self.discord, game, game.type)
+                except Exception as e:
+                    logger.warning(f"Failed to move channel for game {game.id}: {e}")
 
             return game
 

--- a/website/services/game.py
+++ b/website/services/game.py
@@ -467,7 +467,7 @@ class GameService:
 
         game = self.get_by_slug(slug)
 
-        type_upgraded = False
+        type_changed = False
         try:
             # Only allow type/name changes if game is draft
             if game.status == "draft":
@@ -481,18 +481,19 @@ class GameService:
                     )
                 game.name = data["name"]
             elif "type" in data:
-                # Once published, only a one-shot -> campaign upgrade is allowed (a
-                # game running longer than planned), never the reverse, and never
-                # into/out of a special event. Name/slug stay locked outside draft.
+                # Once published, the game may still be switched between one-shot
+                # and campaign (a session growing beyond its planned scope, or a
+                # campaign trimmed down to a single session), but never into/out
+                # of a special event. Name/slug stay locked outside draft.
                 game_type, special_event_id = self.parse_game_type(data["type"])
                 if (
-                    game.type == "oneshot"
-                    and game_type == "campaign"
+                    game_type in ("oneshot", "campaign")
+                    and game_type != game.type
                     and special_event_id is None
                     and game.special_event_id is None
                 ):
                     game.type = game_type
-                    type_upgraded = True
+                    type_changed = True
 
             # Update fields
             game.system_id = data["system"]
@@ -527,12 +528,21 @@ class GameService:
                 except DiscordAPIError as e:
                     logger.warning(f"Failed to update Discord embed for game {game.id}: {e}")
 
-            # Relocate the Discord channel to the campaign category on upgrade
-            if type_upgraded:
+            # Relocate the Discord channel to match the new type's category, and
+            # recolor the player role accordingly. Each is independent: a failure
+            # in one is logged and does not roll back the already-saved type or
+            # block the other.
+            if type_changed:
                 try:
                     self.channel_service.move_game_channel(self.discord, game, game.type)
                 except Exception as e:
                     logger.warning(f"Failed to move channel for game {game.id}: {e}")
+
+                if game.role:
+                    try:
+                        self.discord.update_role_color(game.role, Game.COLORS[game.type])
+                    except Exception as e:
+                        logger.warning(f"Failed to update role color for game {game.id}: {e}")
 
             return game
 

--- a/website/templates/game_form.j2
+++ b/website/templates/game_form.j2
@@ -40,15 +40,18 @@
               <label class="join-item btn btn-sm has-[:checked]:color-oneshot">
                 <input type="radio" name="type" value="oneshot" class="sr-only"
                   {% if not game or game.type == 'oneshot' %}checked{% endif %}
-                  {% if game and game.status != "draft" and not clone %}disabled{% endif %}>
+                  {% if game and game.status != "draft" and not clone and (game.type == 'campaign' or game.special_event_id) %}disabled{% endif %}>
                 <i class="ph ph-scroll" aria-hidden="true"></i> One Shot
               </label>
               <label class="join-item btn btn-sm has-[:checked]:color-campaign">
                 <input type="radio" name="type" value="campaign" class="sr-only"
                   {% if game and game.type == 'campaign' %}checked{% endif %}
-                  {% if game and game.type != 'campaign' and game.status != "draft" and not clone %}disabled{% endif %}>
+                  {% if game and game.type == 'oneshot' and game.special_event_id and game.status != "draft" and not clone %}disabled{% endif %}>
                 <i class="ph ph-books" aria-hidden="true"></i> Campagne
               </label>
+              {# Outside draft, a one-shot may still be upgraded to a campaign
+                 (a session that grows beyond its planned scope); the reverse
+                 and special-event games stay locked, see GameService.update(). #}
               {% if payload.active_events %}
                 {% for event in payload.active_events %}
                   {% set color = hex_color(event.color) %}

--- a/website/templates/game_form.j2
+++ b/website/templates/game_form.j2
@@ -40,18 +40,19 @@
               <label class="join-item btn btn-sm has-[:checked]:color-oneshot">
                 <input type="radio" name="type" value="oneshot" class="sr-only"
                   {% if not game or game.type == 'oneshot' %}checked{% endif %}
-                  {% if game and game.status != "draft" and not clone and (game.type == 'campaign' or game.special_event_id) %}disabled{% endif %}>
+                  {% if game and game.status != "draft" and not clone and game.special_event_id %}disabled{% endif %}>
                 <i class="ph ph-scroll" aria-hidden="true"></i> One Shot
               </label>
               <label class="join-item btn btn-sm has-[:checked]:color-campaign">
                 <input type="radio" name="type" value="campaign" class="sr-only"
                   {% if game and game.type == 'campaign' %}checked{% endif %}
-                  {% if game and game.type == 'oneshot' and game.special_event_id and game.status != "draft" and not clone %}disabled{% endif %}>
+                  {% if game and game.status != "draft" and not clone and game.special_event_id %}disabled{% endif %}>
                 <i class="ph ph-books" aria-hidden="true"></i> Campagne
               </label>
-              {# Outside draft, a one-shot may still be upgraded to a campaign
-                 (a session that grows beyond its planned scope); the reverse
-                 and special-event games stay locked, see GameService.update(). #}
+              {# Outside draft, a one-shot/campaign may still be switched to the
+                 other (a session growing beyond its planned scope, or a campaign
+                 trimmed down); special-event games stay locked entirely, see
+                 GameService.update(). #}
               {% if payload.active_events %}
                 {% for event in payload.active_events %}
                   {% set color = hex_color(event.color) %}


### PR DESCRIPTION
## Summary
- A published one-shot (status `open`/`closed`) can now be switched to a campaign, for the common case of a session growing beyond its planned scope. Previously the game type was only editable while in `draft`.
- The reverse transition (campaign -> one-shot) and games tied to a special event stay locked outside `draft`, unchanged from current behavior.
- When the game already has a Discord channel, it is relocated to a category matching the new type, and tracked category sizes are adjusted accordingly. This is best-effort: a Discord-side failure logs a warning without rolling back the already-saved type change (consistent with how embed refresh failures are already handled in `GameService.update()`).

## Changes
- `website/client/discord.py`: new `Discord.update_channel_parent()` (PATCH `/channels/{id}`).
- `website/services/discord.py`: `DiscordService.update_channel_parent()` wrapper.
- `website/services/channel.py`: new `ChannelService.move_game_channel()` — relocates a game's channel and adjusts category sizes.
- `website/services/game.py`: `GameService.update()` allows the one-shot -> campaign transition outside draft and triggers the channel move.
- `website/templates/game_form.j2`: the "Campagne" option stays selectable when editing a published one-shot.

## Test plan
- [x] Verified locally against a Docker Compose stack (Postgres/Redis) with mocked Discord calls: type flips `oneshot` -> `campaign`, the reverse is rejected, and `move_game_channel` calls `update_channel_parent` with the correct IDs while category sizes move from 1/0 to 0/1.
- [ ] No unit tests added yet in `tests/` — happy to add coverage for `GameService.update()` and `ChannelService.move_game_channel()` if useful before merge.