### PR TITLE
feat(games): bloquer l'inscription en cas de conflit d'horaire

### DIFF
--- a/tests/exceptions/test_business.py
+++ b/tests/exceptions/test_business.py
@@ -6,6 +6,7 @@ from website.exceptions.business import (
     GameClosedError,
     GameError,
     GameFullError,
+    ScheduleConflictError,
     SessionConflictError,
 )
 
@@ -183,6 +184,42 @@ class TestSessionConflictError:
         assert result["details"]["game_id"] == 3
 
 
+class TestScheduleConflictError:
+    """Tests for ScheduleConflictError."""
+
+    def test_inherits_from_game_error(self):
+        err = ScheduleConflictError("Schedule overlaps.")
+        assert isinstance(err, GameError)
+        assert isinstance(err, QuestMasterError)
+
+    def test_default_code(self):
+        err = ScheduleConflictError("Schedule overlaps.")
+        assert err.code == "SCHEDULE_CONFLICT"
+
+    def test_structured_kwargs(self):
+        err = ScheduleConflictError(
+            "Overlaps with another game.", game_id=1, user_id="u1", conflicting_game_id=2
+        )
+        assert err.details["game_id"] == 1
+        assert err.details["user_id"] == "u1"
+        assert err.details["conflicting_game_id"] == 2
+
+    def test_can_be_raised_and_caught_as_game_error(self):
+        with pytest.raises(GameError):
+            raise ScheduleConflictError("conflict.")
+
+    def test_can_be_caught_specifically(self):
+        with pytest.raises(ScheduleConflictError):
+            raise ScheduleConflictError("conflict.")
+
+    def test_to_dict(self):
+        err = ScheduleConflictError("Overlap.", game_id=3, conflicting_game_id=4)
+        result = err.to_dict()
+        assert result["code"] == "SCHEDULE_CONFLICT"
+        assert result["details"]["game_id"] == 3
+        assert result["details"]["conflicting_game_id"] == 4
+
+
 class TestExceptionHierarchyCatching:
     """Test that exception hierarchy allows proper catch patterns."""
 
@@ -193,6 +230,7 @@ class TestExceptionHierarchyCatching:
             GameClosedError("closed."),
             DuplicateRegistrationError("duplicate."),
             SessionConflictError("conflict."),
+            ScheduleConflictError("schedule conflict."),
         ]
         for exc in exceptions:
             with pytest.raises(GameError):
@@ -206,6 +244,7 @@ class TestExceptionHierarchyCatching:
             GameClosedError("closed."),
             DuplicateRegistrationError("duplicate."),
             SessionConflictError("conflict."),
+            ScheduleConflictError("schedule conflict."),
         ]
         for exc in exceptions:
             with pytest.raises(QuestMasterError):
@@ -226,6 +265,7 @@ class TestExceptionHierarchyCatching:
             GameClosedError,
             DuplicateRegistrationError,
             SessionConflictError,
+            ScheduleConflictError,
         ]:
             assert cls("test.").http_status == 409
 
@@ -235,3 +275,4 @@ class TestExceptionHierarchyCatching:
         assert GameClosedError("t.").code == "GAME_CLOSED"
         assert DuplicateRegistrationError("t.").code == "DUPLICATE_REGISTRATION"
         assert SessionConflictError("t.").code == "SESSION_CONFLICT"
+        assert ScheduleConflictError("t.").code == "SCHEDULE_CONFLICT"

--- a/tests/exceptions/test_init.py
+++ b/tests/exceptions/test_init.py
@@ -42,6 +42,9 @@ class TestExceptionPackageExports:
     def test_session_conflict_error(self):
         assert hasattr(exceptions, "SessionConflictError")
 
+    def test_schedule_conflict_error(self):
+        assert hasattr(exceptions, "ScheduleConflictError")
+
     def test_all_exports_match(self):
         expected = {
             "QuestMasterError",
@@ -57,5 +60,6 @@ class TestExceptionPackageExports:
             "DuplicateRegistrationError",
             "SessionConflictError",
             "PastDateError",
+            "ScheduleConflictError",
         }
         assert set(exceptions.__all__) == expected

--- a/tests/services/test_game_service.py
+++ b/tests/services/test_game_service.py
@@ -14,6 +14,7 @@ from website.exceptions import (
     GameFullError,
     NotFoundError,
     PastDateError,
+    ScheduleConflictError,
     ValidationError,
 )
 from website.services.game import GameService
@@ -532,6 +533,78 @@ class TestGameService:
         # Force should bypass both capacity and status checks
         assert regular_user in game.players
         assert len(game.players) == 2
+
+    def test_register_player_schedule_conflict(
+        self, db_session, sample_game, regular_user, admin_user, default_system, game_service
+    ):
+        other_game = GameFactory(
+            db_session, gm_id=admin_user.id, system_id=default_system.id, status="open"
+        )
+        other_game.players.append(regular_user)
+        sample_game.status = "open"
+        db_session.commit()
+
+        with pytest.raises(ScheduleConflictError):
+            game_service.register_player(sample_game.slug, regular_user.id)
+
+        assert regular_user not in sample_game.players
+
+    def test_register_player_force_does_not_bypass_schedule_conflict(
+        self, db_session, sample_game, regular_user, admin_user, default_system, game_service
+    ):
+        other_game = GameFactory(
+            db_session, gm_id=admin_user.id, system_id=default_system.id, status="open"
+        )
+        other_game.players.append(regular_user)
+        sample_game.status = "open"
+        db_session.commit()
+
+        with pytest.raises(ScheduleConflictError):
+            game_service.register_player(sample_game.slug, regular_user.id, force=True)
+
+    def test_register_player_skip_schedule_check_bypasses_conflict(
+        self,
+        db_session,
+        sample_game,
+        regular_user,
+        admin_user,
+        default_system,
+        mock_discord,
+        game_service,
+    ):
+        other_game = GameFactory(
+            db_session, gm_id=admin_user.id, system_id=default_system.id, status="open"
+        )
+        other_game.players.append(regular_user)
+        sample_game.status = "open"
+        db_session.commit()
+
+        game = game_service.register_player(
+            sample_game.slug, regular_user.id, force=True, skip_schedule_check=True
+        )
+
+        assert regular_user in game.players
+
+    def test_register_player_no_conflict_with_archived_game(
+        self,
+        db_session,
+        sample_game,
+        regular_user,
+        admin_user,
+        default_system,
+        mock_discord,
+        game_service,
+    ):
+        other_game = GameFactory(
+            db_session, gm_id=admin_user.id, system_id=default_system.id, status="archived"
+        )
+        other_game.players.append(regular_user)
+        sample_game.status = "open"
+        db_session.commit()
+
+        game = game_service.register_player(sample_game.slug, regular_user.id)
+
+        assert regular_user in game.players
 
     def test_register_player_auto_close(
         self, db_session, sample_game, regular_user, mock_discord, game_service

--- a/tests/views/test_game_views.py
+++ b/tests/views/test_game_views.py
@@ -562,6 +562,39 @@ class TestPlayerRegistration:
         assert response.status_code == 200
         assert "La partie est fermée aux inscriptions." in body
 
+    def test_cannot_register_with_schedule_conflict(
+        self,
+        logged_in_user,
+        mock_discord_lookups,
+        mock_csrf,
+        mock_discord_service,
+        db_session,
+        open_game,
+        default_system,
+        default_vtt,
+        regular_user,
+        admin_user,
+    ):
+        other_game = GameFactory(
+            db_session,
+            gm_id=admin_user.id,
+            system_id=default_system.id,
+            vtt_id=default_vtt.id,
+            status="open",
+        )
+        other_game.players.append(regular_user)
+        # Commit to release the savepoint so the service-level rollback
+        # (on ScheduleConflictError) cannot undo the factory-created game.
+        db_session.commit()
+
+        response = logged_in_user.post(
+            f"/annonces/{open_game.slug}/inscription/",
+            follow_redirects=True,
+        )
+        body = response.data.decode()
+        assert response.status_code == 200
+        assert "Vous avez déjà une partie prévue à cette date et heure." in body
+
     def test_registration_auto_closes_full_game(
         self,
         logged_in_user,

--- a/website/exceptions/__init__.py
+++ b/website/exceptions/__init__.py
@@ -7,6 +7,7 @@ from website.exceptions.business import (
     GameError,
     GameFullError,
     PastDateError,
+    ScheduleConflictError,
     SessionConflictError,
 )
 from website.exceptions.database import DatabaseError
@@ -27,4 +28,5 @@ __all__ = [
     "DuplicateRegistrationError",
     "SessionConflictError",
     "PastDateError",
+    "ScheduleConflictError",
 ]

--- a/website/exceptions/business.py
+++ b/website/exceptions/business.py
@@ -61,6 +61,23 @@ class SessionConflictError(GameError):
         super().__init__(message, details=details, **kwargs)
 
 
+class ScheduleConflictError(GameError):
+    """Player already has another game scheduled at an overlapping time."""
+
+    def __init__(
+        self, message: str, game_id=None, user_id=None, conflicting_game_id=None, **kwargs
+    ):
+        kwargs.setdefault("code", "SCHEDULE_CONFLICT")
+        details = kwargs.pop("details", {})
+        if game_id is not None:
+            details["game_id"] = game_id
+        if user_id is not None:
+            details["user_id"] = user_id
+        if conflicting_game_id is not None:
+            details["conflicting_game_id"] = conflicting_game_id
+        super().__init__(message, details=details, **kwargs)
+
+
 class PastDateError(GameError):
     """Game is being published with a start date in the past.
 

--- a/website/services/game.py
+++ b/website/services/game.py
@@ -22,6 +22,7 @@ from website.exceptions import (
     GameFullError,
     NotFoundError,
     PastDateError,
+    ScheduleConflictError,
     ValidationError,
 )
 from website.extensions import db
@@ -820,18 +821,25 @@ class GameService:
         )
         return True
 
-    def _validate_registration(self, game: Game, user: User, force: bool) -> None:
+    def _validate_registration(
+        self, game: Game, user: User, force: bool, skip_schedule_check: bool = False
+    ) -> None:
         """Validate that a user may register for a game.
 
         Args:
             game: Locked game instance.
             user: User attempting to register.
             force: If True, bypass capacity and status checks.
+            skip_schedule_check: If True, bypass the schedule-conflict check (a
+                trusted GM/admin override, independent of ``force`` since ``force``
+                also covers the untrusted "party selection" auto-bypass).
 
         Raises:
             DuplicateRegistrationError: If the user is already registered.
             GameFullError: If the game is at capacity and force is False.
             GameClosedError: If the game is closed and force is False.
+            ScheduleConflictError: If the user already has another game scheduled
+                at an overlapping time and skip_schedule_check is False.
         """
         if user in game.players:
             raise DuplicateRegistrationError(
@@ -852,6 +860,53 @@ class GameService:
                 "Game is closed for registration.",
                 game_id=game.id,
             )
+
+        if not skip_schedule_check:
+            conflict = self._find_schedule_conflict(user, game)
+            if conflict:
+                raise ScheduleConflictError(
+                    "User already has another game scheduled at an overlapping time.",
+                    game_id=game.id,
+                    user_id=user.id,
+                    conflicting_game_id=conflict.id,
+                )
+
+    @staticmethod
+    def _game_time_windows(game: Game) -> list[tuple[datetime, datetime]]:
+        """Return the time windows a game occupies, for schedule-conflict checks.
+
+        Always includes the announced ``date``/``session_length`` window, plus any
+        additional scheduled ``GameSession`` rows (a campaign's later sessions).
+
+        Args:
+            game: Game instance.
+
+        Returns:
+            List of (start, end) datetime tuples.
+        """
+        windows = [(game.date, game.date + timedelta(hours=float(game.session_length)))]
+        windows.extend((s.start, s.end) for s in game.sessions)
+        return windows
+
+    def _find_schedule_conflict(self, user: User, game: Game) -> Game | None:
+        """Find another active game of the user that overlaps this game's schedule.
+
+        Args:
+            user: Candidate player.
+            game: Game the user is trying to register for.
+
+        Returns:
+            The first conflicting Game, or None if the schedule is clear.
+        """
+        target_windows = self._game_time_windows(game)
+        for other in self.repo.find_by_player_with_relations(user.id):
+            if other.id == game.id or other.status == "archived":
+                continue
+            for t_start, t_end in target_windows:
+                for o_start, o_end in self._game_time_windows(other):
+                    if t_start < o_end and o_start < t_end:
+                        return other
+        return None
 
     def _log_registration_event(self, game: Game, user: User, force: bool) -> None:
         """Log a registration event, distinguishing self-registration from a GM add.
@@ -901,13 +956,23 @@ class GameService:
         logger.info(f"Game {game.id} has been deleted.")
         self._invalidate_dashboard_stats(*affected)
 
-    def register_player(self, slug: str, user_id: str, force: bool = False) -> Game:
+    def register_player(
+        self,
+        slug: str,
+        user_id: str,
+        force: bool = False,
+        skip_schedule_check: bool = False,
+    ) -> Game:
         """Register a player to a game (concurrent-safe).
 
         Args:
             slug: Game slug.
             user_id: User ID to register.
             force: If True, bypass capacity and status checks.
+            skip_schedule_check: If True, bypass the schedule-conflict check (used
+                for a trusted GM/admin override; ``force`` alone is not a reliable
+                trust signal since it is also set for the untrusted "party
+                selection" auto-bypass on public self-registration).
 
         Returns:
             Updated Game instance.
@@ -917,6 +982,8 @@ class GameService:
             DuplicateRegistrationError: If user is already registered.
             GameFullError: If game is at capacity and force is False.
             GameClosedError: If game is closed and force is False.
+            ScheduleConflictError: If the user already has another game at an
+                overlapping time and skip_schedule_check is False.
         """
         game = self.get_by_slug(slug)
         user = self.user_service.get_by_id(user_id)
@@ -931,7 +998,7 @@ class GameService:
                     resource_id=game.id,
                 )
 
-            self._validate_registration(locked_game, user, force)
+            self._validate_registration(locked_game, user, force, skip_schedule_check)
 
             locked_game.players.append(user)
             self._auto_close_if_full(locked_game)
@@ -960,7 +1027,12 @@ class GameService:
             self._invalidate_dashboard_stats(user.id, locked_game.gm_id)
             return locked_game
 
-        except (DuplicateRegistrationError, GameFullError, GameClosedError):
+        except (
+            DuplicateRegistrationError,
+            GameFullError,
+            GameClosedError,
+            ScheduleConflictError,
+        ):
             db.session.rollback()
             raise
         except SQLAlchemyError:

--- a/website/views/games.py
+++ b/website/views/games.py
@@ -18,6 +18,7 @@ from website.exceptions import (
     GameFullError,
     PastDateError,
     QuestMasterError,
+    ScheduleConflictError,
     SessionConflictError,
     UnauthorizedError,
     ValidationError,
@@ -535,6 +536,8 @@ def register_game(slug):
         flash("La partie est complète.", "danger")
     except GameClosedError:
         flash("La partie est fermée aux inscriptions.", "warning")
+    except ScheduleConflictError:
+        flash("Vous avez déjà une partie prévue à cette date et heure.", "warning")
     except QuestMasterError:
         logger.exception("Registration failed")
         flash("Une erreur est survenue pendant l'inscription.", "danger")
@@ -732,7 +735,7 @@ def _handle_add_player(game, slug, data, payload):
         return redirect(url_for(GAME_DETAILS_ROUTE, slug=slug))
 
     force = payload["user_id"] == game.gm_id or payload.get("is_admin", False)
-    game_service.register_player(slug, user.id, force=force)
+    game_service.register_player(slug, user.id, force=force, skip_schedule_check=force)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Résumé
- Empêche un·e joueur·euse de s'inscrire à une annonce (bouton "S'inscrire") s'il/elle a déjà une autre partie prévue sur un créneau qui chevauche celui de l'annonce visée.
- La comparaison se base sur la date/durée annoncée de la partie (`Game.date` + `session_length`) ainsi que sur les sessions déjà planifiées (`GameSession`) pour les campagnes.
- Nouvelle exception `ScheduleConflictError` (même famille que `SessionConflictError`), avec message flash dédié côté vue.
- Le MJ/l'admin peut toujours ajouter un·e joueur·euse manuellement malgré un conflit détecté (nouveau paramètre `skip_schedule_check`, activé uniquement pour cet ajout manuel — indépendant du flag `force` existant, qui sert aussi au mode "sur sélection" et n'est pas un vrai signal de confiance).
- Les parties archivées ne sont pas prises en compte dans la détection de conflit.

Closes #204

## Test plan
- [x] `ruff check` / `ruff format --check` / `pydoclint` passent en local
- [x] Tests unitaires ajoutés : exceptions (`ScheduleConflictError`), service (`register_player` — conflit détecté, `force` ne contourne pas le conflit, `skip_schedule_check` le contourne, partie archivée ignorée), vue (message flash sur conflit)
- [ ] CI (nécessite l'approbation d'un mainteneur pour lancer le workflow sur cette PR externe)